### PR TITLE
release profile

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -8,7 +8,7 @@ assets:
   pubring.gpg: eo-cqrs/eo-cqrs-secrets#assets/pubring.gpg
 merge:
   script: |-
-    mvn clean install -Pqulice-profile -Pqulice --errors --batch-mode
+    mvn clean install -Pqulice --errors --batch-mode
 release:
   pre: false
   sensitive:
@@ -17,5 +17,4 @@ release:
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}"
     git commit -am "${tag}"
-    mvn clean deploy -Pqulice-profile -Pqulice -Psonatype --errors --settings ../settings.xml
-    mvn clean site-deploy -Pgh-pages -Pqulice-profile -Psite --errors --settings ../settings.xml
+    mvn clean deploy -Prelease --errors --settings ../settings.xml


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the Maven commands in the .rultor.yml file. 

### Detailed summary
- Removed the `qulice-profile` and `qulice` profiles from the `mvn clean install` command.
- Removed the `site-deploy` profile from the `mvn clean` command.
- Added the `release` profile to the `mvn clean deploy` command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->